### PR TITLE
Mimic jQuery.fn behaviour

### DIFF
--- a/sprint.js
+++ b/sprint.js
@@ -1419,6 +1419,8 @@
   var Sprint = function(selector, context) {
     return new Init(selector, context)
   }
+  
+  Sprint.fn = Init.prototype;
 
   if (typeof define === "function" && define.amd) {
     define(function() {


### PR DESCRIPTION
This little change allows to extend Sprint object with custom functions just like jQuery #11. This should make writing plugins easier. E.g:
```js
Sprint.foo = function() {
    console.log('bar');
};
$('.bar').foo();
```